### PR TITLE
feat: add docker compose infra

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+POSTGRES_PASSWORD=changeme

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: gamearr
+      POSTGRES_USER: gamearr
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - ../data/postgres:/var/lib/postgresql/data
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    volumes:
+      - ../data/redis:/data
+  qbittorrent:
+    image: lscr.io/linuxserver/qbittorrent:latest
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ../data/qbittorrent:/config
+      - ../data/downloads:/downloads
+  sabnzbd:
+    image: lscr.io/linuxserver/sabnzbd:latest
+    restart: unless-stopped
+    ports:
+      - "8070:8080"
+    volumes:
+      - ../data/sabnzbd:/config
+      - ../data/downloads:/downloads


### PR DESCRIPTION
## Summary
- add infrastructure docker compose file with postgres, redis, qbittorrent and sabnzbd
- add example env file for postgres password

## Testing
- `docker compose up -d` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad31c31aa48330ba64fa0778dfae8b