### PR TITLE
feat(storage): add prisma setup

### DIFF
--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -6,6 +6,14 @@
     "build": "echo build storage",
     "dev": "echo dev storage",
     "lint": "echo lint storage",
-    "test": "echo test storage"
+    "test": "echo test storage",
+    "migrate:dev": "prisma migrate dev",
+    "studio": "prisma studio"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.15.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.15.0"
   }
 }

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -1,0 +1,64 @@
+// Prisma schema for storage module
+// This schema uses PostgreSQL database
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Platform {
+  id        String     @id @default(cuid())
+  name      String     @unique
+  artifacts Artifact[]
+}
+
+model Library {
+  id    String @id @default(cuid())
+  name  String
+  path  String @unique
+  games Game[]
+}
+
+model Game {
+  id        String   @id @default(cuid())
+  libraryId String
+  library   Library  @relation(fields: [libraryId], references: [id])
+  title     String
+  slug      String   @unique
+  releases  Release[]
+}
+
+model Release {
+  id        String    @id @default(cuid())
+  gameId    String
+  game      Game      @relation(fields: [gameId], references: [id])
+  version   String
+  artifacts Artifact[]
+  createdAt DateTime  @default(now())
+}
+
+model Artifact {
+  id         String    @id @default(cuid())
+  releaseId  String
+  release    Release   @relation(fields: [releaseId], references: [id])
+  platformId String
+  platform   Platform  @relation(fields: [platformId], references: [id])
+  fileName   String
+  fileSize   Int
+  sha256     String    @unique
+  downloads  Download[]
+}
+
+model Download {
+  id         String   @id @default(cuid())
+  artifactId String
+  artifact   Artifact @relation(fields: [artifactId], references: [id])
+  url        String
+  sha256     String?
+  createdAt  DateTime @default(now())
+}
+

--- a/packages/storage/src/client.ts
+++ b/packages/storage/src/client.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add Prisma schema and client for storage package
- wire up migrate and studio scripts

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*
- `DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres" pnpm -w dlx prisma migrate dev --schema packages/storage/prisma/schema.prisma --name init` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68ad393c626c83308f1678e039b57f0d