### PR TITLE
feat(metadata): add RAWG metadata search

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
     "test": "echo test api"
   },
   "dependencies": {
+    "@gamearr/adapters": "workspace:*",
     "@gamearr/shared": "workspace:*",
     "@gamearr/storage": "workspace:*",
     "@nestjs/common": "^10.0.0",

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -3,8 +3,9 @@ import { ConfigModule } from './config/config.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { HealthModule } from './health/health.module';
 import { LibraryModule } from './library/library.module';
+import { MetadataModule } from './metadata/metadata.module';
 
 @Module({
-  imports: [ConfigModule, PrismaModule, HealthModule, LibraryModule],
+  imports: [ConfigModule, PrismaModule, HealthModule, LibraryModule, MetadataModule],
 })
 export class AppModule {}

--- a/apps/api/src/metadata/metadata.controller.ts
+++ b/apps/api/src/metadata/metadata.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { MetadataService } from './metadata.service';
+
+@Controller('metadata')
+export class MetadataController {
+  constructor(private readonly service: MetadataService) {}
+
+  @Get('search')
+  search(
+    @Query('q') q: string,
+    @Query('platform') platform: string,
+    @Query('year') year?: string,
+  ) {
+    return this.service.search(q, platform, year ? parseInt(year, 10) : undefined);
+  }
+}

--- a/apps/api/src/metadata/metadata.module.ts
+++ b/apps/api/src/metadata/metadata.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { MetadataController } from './metadata.controller';
+import { MetadataService } from './metadata.service';
+
+@Module({
+  controllers: [MetadataController],
+  providers: [MetadataService],
+})
+export class MetadataModule {}

--- a/apps/api/src/metadata/metadata.service.ts
+++ b/apps/api/src/metadata/metadata.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { rawg } from '@gamearr/adapters';
+
+@Injectable()
+export class MetadataService {
+  private readonly providers = [rawg];
+
+  async search(title: string, platform: string, year?: number) {
+    const results = await Promise.all(
+      this.providers.map((p) => p.searchGame({ title, platform, year }))
+    );
+    return results.flat();
+  }
+}

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -2,8 +2,10 @@
   "name": "@gamearr/adapters",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
+  "main": "src/index.ts",
   "scripts": {
-    "build": "echo build adapters",
+    "build": "tsc -p tsconfig.json",
     "dev": "echo dev adapters",
     "lint": "echo lint adapters",
     "test": "echo test adapters"

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,3 +1,7 @@
-import * as rawg from './providers/rawg';
+import * as rawgModule from './providers/rawg';
 
-export { rawg };
+// Create and export the rawg object
+export const rawg = {
+  searchGame: rawgModule.searchGame,
+  getGame: rawgModule.getGame
+};

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,1 +1,1 @@
-export const adapters = {};
+export * as rawg from './providers/rawg';

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,1 +1,3 @@
-export * as rawg from './providers/rawg';
+import * as rawg from './providers/rawg';
+
+export { rawg };

--- a/packages/adapters/src/providers/rawg.ts
+++ b/packages/adapters/src/providers/rawg.ts
@@ -1,0 +1,76 @@
+import { config } from '@gamearr/shared';
+
+const BASE_URL = 'https://api.rawg.io/api';
+
+async function rawgFetch(path: string, params: Record<string, string | number | undefined> = {}, attempt = 0): Promise<any> {
+  const url = new URL(path, BASE_URL);
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  if (config.rawgKey) {
+    url.searchParams.set('key', config.rawgKey);
+  }
+
+  const res = await fetch(url.toString());
+  if (res.status === 429 && attempt < 3) {
+    const retryAfter = parseInt(res.headers.get('Retry-After') || '1', 10);
+    await new Promise((r) => setTimeout(r, retryAfter * 1000));
+    return rawgFetch(path, params, attempt + 1);
+  }
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`RAWG request failed: ${res.status} ${text}`);
+  }
+  return res.json();
+}
+
+export async function searchGame({
+  title,
+  platform,
+  year,
+}: {
+  title: string;
+  platform: string;
+  year?: number;
+}): Promise<{ id: string; title: string; year?: number; coverUrl?: string }[]> {
+  const params: Record<string, string> = {
+    search: title,
+    page_size: '10',
+  };
+  if (platform) {
+    params.platforms = platform;
+  }
+  if (year) {
+    params.dates = `${year}-01-01,${year}-12-31`;
+  }
+  const data = await rawgFetch('/games', params);
+  return (data.results || []).map((g: any) => ({
+    id: String(g.id),
+    title: g.name,
+    year: g.released ? parseInt(g.released.slice(0, 4)) : undefined,
+    coverUrl: g.background_image,
+  }));
+}
+
+export async function getGame(id: string): Promise<{
+  id: string;
+  title: string;
+  year?: number;
+  coverUrl?: string;
+  screenshots: string[];
+  genres: string[];
+  publishers: string[];
+}> {
+  const data = await rawgFetch(`/games/${id}`);
+  return {
+    id: String(data.id),
+    title: data.name,
+    year: data.released ? parseInt(data.released.slice(0, 4)) : undefined,
+    coverUrl: data.background_image,
+    screenshots: (data.short_screenshots || []).map((s: any) => s.image),
+    genres: (data.genres || []).map((g: any) => g.name),
+    publishers: (data.publishers || []).map((p: any) => p.name),
+  };
+}

--- a/packages/adapters/src/providers/rawg.ts
+++ b/packages/adapters/src/providers/rawg.ts
@@ -26,7 +26,7 @@ async function rawgFetch(path: string, params: Record<string, string | number | 
   return res.json();
 }
 
-export async function searchGame({
+async function searchGame({
   title,
   platform,
   year,
@@ -54,7 +54,7 @@ export async function searchGame({
   }));
 }
 
-export async function getGame(id: string): Promise<{
+async function getGame(id: string): Promise<{
   id: string;
   title: string;
   year?: number;
@@ -74,3 +74,6 @@ export async function getGame(id: string): Promise<{
     publishers: (data.publishers || []).map((p: any) => p.name),
   };
 }
+
+// Export the functions directly
+export { searchGame, getGame };

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,7 +12,8 @@
       "@gamearr/shared": ["packages/shared/src"],
       "@gamearr/domain": ["packages/domain/src"],
       "@gamearr/storage": ["packages/storage/src"],
-      "@gamearr/storage/*": ["packages/storage/*"]
+      "@gamearr/storage/*": ["packages/storage/*"],
+      "@gamearr/adapters": ["packages/adapters/src"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add RAWG provider with search and game detail APIs
- expose metadata search endpoint in API
- wire up RAWG adapter and metadata module

## Testing
- `pnpm test` *(fails: Could not find '/workspace/gamarr/packages/shared/dist/**/*.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ae5f1d601c8330bbe8d3d59d4dd38f