### PR TITLE
feat(match): add artifact matching

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -4,8 +4,16 @@ import { PrismaModule } from './prisma/prisma.module';
 import { HealthModule } from './health/health.module';
 import { LibraryModule } from './library/library.module';
 import { MetadataModule } from './metadata/metadata.module';
+import { MatchModule } from './match/match.module';
 
 @Module({
-  imports: [ConfigModule, PrismaModule, HealthModule, LibraryModule, MetadataModule],
+  imports: [
+    ConfigModule,
+    PrismaModule,
+    HealthModule,
+    LibraryModule,
+    MetadataModule,
+    MatchModule,
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/match/match.controller.ts
+++ b/apps/api/src/match/match.controller.ts
@@ -1,0 +1,22 @@
+import { Body, Controller, Get, Param, Post, Query } from '@nestjs/common';
+import { MatchService } from './match.service';
+
+@Controller('artifacts')
+export class MatchController {
+  constructor(private readonly service: MatchService) {}
+
+  @Get('unmatched')
+  getUnmatched(@Query('page') page = '1', @Query('limit') limit = '50') {
+    const take = parseInt(limit, 10);
+    const skip = (parseInt(page, 10) - 1) * take;
+    return this.service.findUnmatched(skip, take);
+    }
+
+  @Post(':id/match')
+  match(
+    @Param('id') id: string,
+    @Body() body: { provider: string; providerId: string },
+  ) {
+    return this.service.matchArtifact(id, body.provider, body.providerId);
+  }
+}

--- a/apps/api/src/match/match.module.ts
+++ b/apps/api/src/match/match.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { MatchController } from './match.controller';
+import { MatchService } from './match.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [MatchController],
+  providers: [MatchService],
+})
+export class MatchModule {}

--- a/apps/api/src/match/match.service.ts
+++ b/apps/api/src/match/match.service.ts
@@ -1,0 +1,52 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { rawg } from '@gamearr/adapters';
+
+@Injectable()
+export class MatchService {
+  private readonly providers = {
+    rawg,
+  };
+
+  constructor(private readonly prisma: PrismaClient) {}
+
+  findUnmatched(skip: number, take: number) {
+    return this.prisma.artifact.findMany({
+      where: { releaseId: null },
+      skip,
+      take,
+    });
+  }
+
+  async matchArtifact(
+    id: string,
+    provider: string,
+    providerId: string,
+  ) {
+    const artifact = await this.prisma.artifact.findUnique({ where: { id } });
+    if (!artifact) {
+      throw new NotFoundException('Artifact not found');
+    }
+    const providerApi = (this.providers as any)[provider];
+    if (!providerApi) {
+      throw new NotFoundException('Unknown provider');
+    }
+    const gameData = await providerApi.getGame(providerId);
+    let game = await this.prisma.game.findFirst({
+      where: { provider, providerId },
+    });
+    if (!game) {
+      game = await this.prisma.game.create({
+        data: { title: gameData.title, provider, providerId },
+      });
+    }
+    const release = await this.prisma.release.create({
+      data: { gameId: game.id },
+    });
+    await this.prisma.artifact.update({
+      where: { id: artifact.id },
+      data: { releaseId: release.id },
+    });
+    return { game, release };
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,1 +1,63 @@
-export const App = () => <div>web</div>;
+import { useEffect, useState } from 'react';
+
+type Artifact = { id: string; path: string };
+type SearchResult = { id: string; title: string };
+
+export const App = () => {
+  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
+  const [selected, setSelected] = useState<Artifact | null>(null);
+  const [results, setResults] = useState<SearchResult[]>([]);
+
+  useEffect(() => {
+    fetch('/artifacts/unmatched')
+      .then((r) => r.json())
+      .then(setArtifacts);
+  }, []);
+
+  const open = async (a: Artifact) => {
+    setSelected(a);
+    const name = a.path.split('/').pop() || '';
+    const res = await fetch(
+      `/metadata/search?q=${encodeURIComponent(name)}&platform=`
+    ).then((r) => r.json());
+    setResults(res);
+  };
+
+  const approve = async (artifactId: string, providerId: string) => {
+    await fetch(`/artifacts/${artifactId}/match`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider: 'rawg', providerId }),
+    });
+    setArtifacts(artifacts.filter((a) => a.id !== artifactId));
+    setSelected(null);
+    setResults([]);
+  };
+
+  return (
+    <div style={{ display: 'flex' }}>
+      <div style={{ flex: 1 }}>
+        <ul>
+          {artifacts.map((a) => (
+            <li key={a.id} onClick={() => open(a)} style={{ cursor: 'pointer' }}>
+              {a.path}
+            </li>
+          ))}
+        </ul>
+      </div>
+      {selected && (
+        <div style={{ width: '400px', borderLeft: '1px solid #ccc', padding: '1rem' }}>
+          <h2>{selected.path}</h2>
+          <ul>
+            {results.map((r) => (
+              <li key={r.id}>
+                {r.title}{' '}
+                <button onClick={() => approve(selected.id, r.id)}>Approve</button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -35,7 +35,28 @@ model Artifact {
   sha1      String?
   format    String?
   multiPartGroup String? @map("multi_part_group")
+  releaseId String?
+  release   Release? @relation(fields: [releaseId], references: [id])
 
   @@unique([libraryId, path])
+}
+
+model Game {
+  id         String    @id @default(cuid())
+  title      String
+  provider   String
+  providerId String
+  releases   Release[]
+
+  @@unique([provider, providerId])
+}
+
+model Release {
+  id       String   @id @default(cuid())
+  gameId   String
+  game     Game     @relation(fields: [gameId], references: [id])
+  region   String?
+  language String?
+  artifacts Artifact[]
 }
 


### PR DESCRIPTION
## Summary
- add game and release models with artifact matching relations
- expose artifacts matching endpoints in API
- build unmatched artifacts UI with RAWG search and approval

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae71e6913483308d287fc2c959397b