### PR TITLE
feat: organize artifacts with templates

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,12 +7,13 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/main.ts",
     "lint": "echo lint api",
-    "test": "echo test api"
+    "test": "tsc -p tsconfig.json && node --test dist"
   },
   "dependencies": {
     "@gamearr/adapters": "workspace:*",
     "@gamearr/shared": "workspace:*",
     "@gamearr/storage": "workspace:*",
+    "@gamearr/domain": "workspace:*",
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
@@ -24,6 +25,7 @@
   "devDependencies": {
     "tsx": "^4.0.0",
     "@types/node": "^20.0.0",
-    "@types/express": "^4.17.21"
+    "@types/express": "^4.17.21",
+    "@nestjs/testing": "^10.0.0"
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -5,6 +5,7 @@ import { HealthModule } from './health/health.module';
 import { LibraryModule } from './library/library.module';
 import { MetadataModule } from './metadata/metadata.module';
 import { MatchModule } from './match/match.module';
+import { ImportsModule } from './imports/imports.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { MatchModule } from './match/match.module';
     LibraryModule,
     MetadataModule,
     MatchModule,
+    ImportsModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/imports/imports.controller.ts
+++ b/apps/api/src/imports/imports.controller.ts
@@ -1,0 +1,12 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ImportsService } from './imports.service.js';
+
+@Controller('imports')
+export class ImportsController {
+  constructor(private readonly service: ImportsService) {}
+
+  @Post('organize')
+  organize(@Body() body: { artifactId: string; template: string }) {
+    return this.service.organize(body.artifactId, body.template);
+  }
+}

--- a/apps/api/src/imports/imports.module.ts
+++ b/apps/api/src/imports/imports.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { ImportsController } from './imports.controller.js';
+import { ImportsService } from './imports.service.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ImportsController],
+  providers: [ImportsService],
+})
+export class ImportsModule {}

--- a/apps/api/src/imports/imports.service.ts
+++ b/apps/api/src/imports/imports.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { moveArtifact } from '@gamearr/domain';
+
+@Injectable()
+export class ImportsService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async organize(artifactId: string, template: string) {
+    const artifact = await this.prisma.artifact.findUnique({
+      where: { id: artifactId },
+      include: {
+        library: { include: { platform: true } },
+        release: { include: { game: true } },
+      },
+    });
+    if (!artifact) {
+      throw new NotFoundException('Artifact not found');
+    }
+    const path = await moveArtifact(artifact as any, template);
+    return { path };
+  }
+}

--- a/apps/api/src/imports/organize.test.ts
+++ b/apps/api/src/imports/organize.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { Test as NestTest } from '@nestjs/testing';
+import { PrismaClient } from '@prisma/client';
+import { ImportsController } from './imports.controller.js';
+import { ImportsService } from './imports.service.js';
+
+test('POST /imports/organize moves artifact', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'organize-'));
+  const libraryPath = path.join(tmp, 'library');
+  await fs.mkdir(libraryPath, { recursive: true });
+  const source = path.join(libraryPath, 'Sonic.bin');
+  await fs.writeFile(source, 'data');
+  await fs.rm('/roms', { recursive: true, force: true });
+
+  const artifact = {
+    id: '1',
+    path: 'Sonic.bin',
+    multiPartGroup: null,
+    library: { path: libraryPath, platform: { name: 'Dreamcast' } },
+    release: { game: { title: 'Sonic' } },
+  };
+
+  const prismaStub = {
+    artifact: {
+      findUnique: async () => artifact,
+    },
+  };
+
+  const moduleRef = await NestTest.createTestingModule({
+    controllers: [ImportsController],
+    providers: [ImportsService, { provide: PrismaClient, useValue: prismaStub }],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  await app.listen(0);
+  const server = app.getHttpServer();
+  const { port } = server.address();
+
+  const template = '${game}${disc? ` (Disc ${disc})`:``}';
+  const res = await fetch(`http://localhost:${port}/imports/organize`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ artifactId: '1', template }),
+  });
+  const json = await res.json();
+  assert.equal(json.path, '/roms/Dreamcast/Sonic.bin');
+  const moved = await fs.readFile('/roms/Dreamcast/Sonic.bin', 'utf8');
+  assert.equal(moved, 'data');
+  await app.close();
+});

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -3,10 +3,14 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+  "main": "dist/index.js",
   "scripts": {
     "build": "echo build domain",
     "dev": "echo dev domain",
     "lint": "echo lint domain",
     "test": "tsc -p tsconfig.json && node --test dist/**/*.test.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0"
   }
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,7 @@
 // @ts-nocheck
-export * from './fs/walk';
-export * from './hash/hasher';
-export * from './parsers/cue';
-export * from './parsers/gdi';
+export * from './fs/walk.js';
+export * from './hash/hasher.js';
+export * from './parsers/cue.js';
+export * from './parsers/gdi.js';
+export * from './organize/renderTemplate.js';
+export * from './organize/moveArtifact.js';

--- a/packages/domain/src/organize/moveArtifact.ts
+++ b/packages/domain/src/organize/moveArtifact.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { renderTemplate } from './renderTemplate.js';
+
+export interface ArtifactInfo {
+  path: string;
+  multiPartGroup?: string | null;
+  library: { path: string; platform: { name: string } };
+  release?: { game: { title: string } };
+}
+
+export async function moveArtifact(
+  artifact: ArtifactInfo,
+  template: string,
+  romsRoot = '/roms',
+): Promise<string> {
+  const src = path.join(artifact.library.path, artifact.path);
+  const ext = path.extname(artifact.path);
+  const ctx = {
+    platform: artifact.library.platform.name,
+    game: artifact.release?.game.title ?? path.parse(artifact.path).name,
+    disc: artifact.multiPartGroup ?? '',
+    ext,
+  } as Record<string, unknown>;
+  const name = renderTemplate(ctx, template) + ext;
+  const dest = path.join(romsRoot, artifact.library.platform.name, name);
+  await fs.mkdir(path.dirname(dest), { recursive: true });
+  await fs.rename(src, dest);
+  return dest;
+}

--- a/packages/domain/src/organize/renderTemplate.test.ts
+++ b/packages/domain/src/organize/renderTemplate.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderTemplate } from './renderTemplate.js';
+
+test('renders variables', () => {
+  const result = renderTemplate({ name: 'World' }, 'Hello ${name}');
+  assert.equal(result, 'Hello World');
+});
+
+test('missing variables become empty', () => {
+  const result = renderTemplate({}, 'Hello ${name}!');
+  assert.equal(result, 'Hello !');
+});
+
+test('supports simple ternaries', () => {
+  const tpl = 'Game${disc? ` (Disc ${disc})`:``}';
+  assert.equal(renderTemplate({ disc: 1 }, tpl), 'Game (Disc 1)');
+  assert.equal(renderTemplate({}, tpl), 'Game');
+});

--- a/packages/domain/src/organize/renderTemplate.ts
+++ b/packages/domain/src/organize/renderTemplate.ts
@@ -1,0 +1,15 @@
+export function renderTemplate(
+  ctx: Record<string, unknown>,
+  tpl: string,
+): string {
+  const proxy = new Proxy(ctx, {
+    has: () => true,
+    get(target, prop: string) {
+      const value = (target as any)[prop];
+      return value === undefined || value === null ? '' : value;
+    },
+  });
+  // eslint-disable-next-line no-new-func
+  const fn = new Function('ctx', 'with (ctx) { return `'+tpl+'`; }');
+  return fn(proxy);
+}

--- a/packages/domain/tsconfig.json
+++ b/packages/domain/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add lightweight template renderer with variable and ternary support
- move artifacts with user templates and expose via new Imports API
- exercise template edge cases and `/imports/organize` flow in tests

## Testing
- `pnpm --filter @gamearr/domain test`
- `pnpm --filter @gamearr/api test`


------
https://chatgpt.com/codex/tasks/task_e_68ae747daedc8330a32973eed9a1bf2c