### PR TITLE
feat: add emulationstation exporter

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -7,6 +7,7 @@ import { MetadataModule } from './metadata/metadata.module';
 import { MatchModule } from './match/match.module';
 import { ImportsModule } from './imports/imports.module';
 import { DownloadsModule } from './downloads/downloads.module';
+import { ExportsModule } from './exports/exports.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { DownloadsModule } from './downloads/downloads.module';
     MatchModule,
     ImportsModule,
     DownloadsModule,
+    ExportsModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/exports/exports.controller.ts
+++ b/apps/api/src/exports/exports.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Post } from '@nestjs/common';
+import { ExportsService } from './exports.service';
+
+@Controller('exports')
+export class ExportsController {
+  constructor(private readonly service: ExportsService) {}
+
+  @Post('emulationstation')
+  emulationstation() {
+    return this.service.emulationstation();
+  }
+}

--- a/apps/api/src/exports/exports.module.ts
+++ b/apps/api/src/exports/exports.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ExportsService } from './exports.service';
+import { ExportsController } from './exports.controller';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ExportsController],
+  providers: [ExportsService],
+})
+export class ExportsModule {}

--- a/apps/api/src/exports/exports.service.ts
+++ b/apps/api/src/exports/exports.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+import { emulationstation } from '@gamearr/adapters';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+
+@Injectable()
+export class ExportsService {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async emulationstation() {
+    const tmp = await mkdtemp(path.join(tmpdir(), 'es-export-'));
+    await emulationstation.exportAll({ prisma: this.prisma, outDir: tmp });
+    const target = path.resolve('emulationstation');
+    await fs.rm(target, { recursive: true, force: true });
+    await fs.rename(tmp, target);
+    return { status: 'ok' };
+  }
+}

--- a/packages/adapters/src/exporters/emulationstation.ts
+++ b/packages/adapters/src/exporters/emulationstation.ts
@@ -1,0 +1,127 @@
+import fs from 'node:fs/promises';
+import { createWriteStream } from 'node:fs';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { getGame as rawgGetGame } from '../providers/rawg';
+
+function slugify(str: string) {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function escapeXml(str: string) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const providerGetters: Record<string, (id: string) => Promise<any>> = {
+  rawg: rawgGetGame,
+};
+
+export async function exportEmulationStation({
+  prisma,
+  outDir,
+}: {
+  prisma: any;
+  outDir: string;
+}) {
+  const platforms = await prisma.platform.findMany({
+    include: {
+      libraries: {
+        include: {
+          artifacts: {
+            where: { releaseId: { not: null } },
+            include: { release: { include: { game: true } } },
+          },
+        },
+      },
+    },
+  });
+
+  const assetsRoot = path.join(outDir, 'assets');
+  await fs.mkdir(assetsRoot, { recursive: true });
+
+  const gameCache = new Map<string, any>();
+
+  for (const platform of platforms) {
+    const platformDir = path.join(outDir, platform.name);
+    await fs.mkdir(platformDir, { recursive: true });
+    const entries: string[] = [];
+
+    for (const library of platform.libraries) {
+      for (const artifact of library.artifacts) {
+        if (!artifact.release) continue;
+        const game = artifact.release.game;
+        const key = `${game.provider}:${game.providerId}`;
+        if (!gameCache.has(key)) {
+          const getter = providerGetters[game.provider];
+          if (getter) {
+            try {
+              const data = await getter(game.providerId);
+              gameCache.set(key, data);
+            } catch {
+              gameCache.set(key, {});
+            }
+          } else {
+            gameCache.set(key, {});
+          }
+        }
+        const details = gameCache.get(key) || {};
+        const slug = slugify(game.title);
+        const assetDir = path.join(assetsRoot, platform.name, slug);
+        await fs.mkdir(assetDir, { recursive: true });
+
+        let imageRel: string | undefined;
+        if (details.coverUrl) {
+          try {
+            const res = await fetch(details.coverUrl);
+            if (res.ok && res.body) {
+              const ext = path.extname(new URL(details.coverUrl).pathname) || '.jpg';
+              const imgPath = path.join(assetDir, 'image' + ext);
+              await pipeline(res.body, createWriteStream(imgPath));
+              imageRel = path.relative(platformDir, imgPath);
+            }
+          } catch {
+            // ignore download errors
+          }
+        }
+
+        let videoRel: string | undefined;
+        if (details.videoUrl) {
+          try {
+            const res = await fetch(details.videoUrl);
+            if (res.ok && res.body) {
+              const ext = path.extname(new URL(details.videoUrl).pathname) || '.mp4';
+              const vidPath = path.join(assetDir, 'video' + ext);
+              await pipeline(res.body, createWriteStream(vidPath));
+              videoRel = path.relative(platformDir, vidPath);
+            }
+          } catch {
+            // ignore download errors
+          }
+        }
+
+        const lines: string[] = [];
+        lines.push('  <game>');
+        lines.push(`    <path>${escapeXml(artifact.path)}</path>`);
+        lines.push(`    <name>${escapeXml(game.title)}</name>`);
+        lines.push(`    <desc>${escapeXml(details.description || '')}</desc>`);
+        if (imageRel) lines.push(`    <image>${escapeXml(imageRel)}</image>`);
+        if (videoRel) lines.push(`    <video>${escapeXml(videoRel)}</video>`);
+        lines.push('  </game>');
+        entries.push(lines.join('\n'));
+      }
+    }
+
+    const xml = ['<?xml version="1.0"?>', '<gameList>', ...entries, '</gameList>'].join('\n');
+    await fs.writeFile(path.join(platformDir, 'gamelist.xml'), xml, 'utf8');
+  }
+}
+
+export default { exportEmulationStation };

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -1,5 +1,6 @@
 import * as rawgModule from './providers/rawg';
 import * as qbittorrentModule from './downloads/qbittorrent';
+import * as emulationstationModule from './exporters/emulationstation';
 
 // Create and export the rawg object
 export const rawg = {
@@ -10,4 +11,8 @@ export const rawg = {
 export const qbittorrent = {
   addMagnet: qbittorrentModule.addMagnet,
   getStatus: qbittorrentModule.getStatus,
+};
+
+export const emulationstation = {
+  exportAll: emulationstationModule.exportEmulationStation,
 };

--- a/packages/adapters/src/providers/rawg.ts
+++ b/packages/adapters/src/providers/rawg.ts
@@ -59,6 +59,8 @@ async function getGame(id: string): Promise<{
   title: string;
   year?: number;
   coverUrl?: string;
+  description?: string;
+  videoUrl?: string;
   screenshots: string[];
   genres: string[];
   publishers: string[];
@@ -69,6 +71,8 @@ async function getGame(id: string): Promise<{
     title: data.name,
     year: data.released ? parseInt(data.released.slice(0, 4)) : undefined,
     coverUrl: data.background_image,
+    description: data.description_raw,
+    videoUrl: data.clip?.clip,
     screenshots: (data.short_screenshots || []).map((s: any) => s.image),
     genres: (data.genres || []).map((g: any) => g.name),
     publishers: (data.publishers || []).map((p: any) => p.name),


### PR DESCRIPTION
## Summary
- add EmulationStation exporter that builds platform gamelists and downloads assets
- expose POST /exports/emulationstation to regenerate exports atomically
- extend RAWG provider with description and video metadata

## Testing
- `pnpm test` *(fails: Cannot find module '@nestjs/common')*

------
https://chatgpt.com/codex/tasks/task_e_68af5e6a8940833098d48d98a328dd42