### PR TITLE
feat: add one game one rom service

### DIFF
--- a/apps/web/src/Settings.tsx
+++ b/apps/web/src/Settings.tsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+export const Settings = () => {
+  const [regionPriority, setRegionPriority] = useState(
+    localStorage.getItem('regionPriority') || 'USA,Europe,Japan',
+  );
+  const [preferVerified, setPreferVerified] = useState(
+    localStorage.getItem('preferVerified') !== 'false',
+  );
+  const [preferRevision, setPreferRevision] = useState(
+    localStorage.getItem('preferRevision') !== 'false',
+  );
+
+  useEffect(() => {
+    localStorage.setItem('regionPriority', regionPriority);
+  }, [regionPriority]);
+  useEffect(() => {
+    localStorage.setItem('preferVerified', String(preferVerified));
+  }, [preferVerified]);
+  useEffect(() => {
+    localStorage.setItem('preferRevision', String(preferRevision));
+  }, [preferRevision]);
+
+  return (
+    <div>
+      <h2>Settings</h2>
+      <div>
+        <label>Region Priority (comma separated):</label>
+        <input
+          value={regionPriority}
+          onChange={(e) => setRegionPriority(e.target.value)}
+          style={{ width: '100%' }}
+        />
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={preferVerified}
+            onChange={(e) => setPreferVerified(e.target.checked)}
+          />
+          Prefer verified dumps
+        </label>
+      </div>
+      <div>
+        <label>
+          <input
+            type="checkbox"
+            checked={preferRevision}
+            onChange={(e) => setPreferRevision(e.target.checked)}
+          />
+          Prefer highest revision
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Settings } from './Settings';
 
 type Artifact = { id: string; path: string };
 type SearchResult = { id: string; title: string };
@@ -7,6 +8,7 @@ export const App = () => {
   const [artifacts, setArtifacts] = useState<Artifact[]>([]);
   const [selected, setSelected] = useState<Artifact | null>(null);
   const [results, setResults] = useState<SearchResult[]>([]);
+  const [showSettings, setShowSettings] = useState(false);
 
   useEffect(() => {
     fetch('/artifacts/unmatched')
@@ -34,30 +36,34 @@ export const App = () => {
     setResults([]);
   };
 
-  return (
-    <div style={{ display: 'flex' }}>
-      <div style={{ flex: 1 }}>
-        <ul>
-          {artifacts.map((a) => (
-            <li key={a.id} onClick={() => open(a)} style={{ cursor: 'pointer' }}>
-              {a.path}
-            </li>
-          ))}
-        </ul>
-      </div>
-      {selected && (
-        <div style={{ width: '400px', borderLeft: '1px solid #ccc', padding: '1rem' }}>
-          <h2>{selected.path}</h2>
-          <ul>
-            {results.map((r) => (
-              <li key={r.id}>
-                {r.title}{' '}
-                <button onClick={() => approve(selected.id, r.id)}>Approve</button>
-              </li>
-            ))}
-          </ul>
+    return (
+      <div>
+        <button onClick={() => setShowSettings(!showSettings)}>Settings</button>
+        {showSettings && <Settings />}
+        <div style={{ display: 'flex' }}>
+          <div style={{ flex: 1 }}>
+            <ul>
+              {artifacts.map((a) => (
+                <li key={a.id} onClick={() => open(a)} style={{ cursor: 'pointer' }}>
+                  {a.path}
+                </li>
+              ))}
+            </ul>
+          </div>
+          {selected && (
+            <div style={{ width: '400px', borderLeft: '1px solid #ccc', padding: '1rem' }}>
+              <h2>{selected.path}</h2>
+              <ul>
+                {results.map((r) => (
+                  <li key={r.id}>
+                    {r.title}{' '}
+                    <button onClick={() => approve(selected.id, r.id)}>Approve</button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
-      )}
-    </div>
-  );
-};
+      </div>
+    );
+  };

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -11,6 +11,7 @@
     "test": "echo test adapters"
   },
   "dependencies": {
-    "fast-xml-parser": "^5.2.5"
+    "fast-xml-parser": "^5.2.5",
+    "@gamearr/domain": "workspace:*"
   }
 }

--- a/packages/adapters/src/exporters/emulationstation.ts
+++ b/packages/adapters/src/exporters/emulationstation.ts
@@ -3,6 +3,7 @@ import { createWriteStream } from 'node:fs';
 import path from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import { getGame as rawgGetGame } from '../providers/rawg';
+import { pickWinner, OgoPreferences } from '@gamearr/domain';
 
 function slugify(str: string) {
   return str
@@ -48,15 +49,44 @@ export async function exportEmulationStation({
   await fs.mkdir(assetsRoot, { recursive: true });
 
   const gameCache = new Map<string, any>();
+  const prefs: OgoPreferences = {
+    regionPriority: ['USA', 'Europe', 'Japan'],
+    preferVerified: true,
+    preferHighestRevision: true,
+  };
 
   for (const platform of platforms) {
     const platformDir = path.join(outDir, platform.name);
     await fs.mkdir(platformDir, { recursive: true });
     const entries: string[] = [];
 
+    const gameArtifacts = new Map<string, any[]>();
     for (const library of platform.libraries) {
       for (const artifact of library.artifacts) {
         if (!artifact.release) continue;
+        const gameId = artifact.release.game.id;
+        const arr = gameArtifacts.get(gameId) || [];
+        arr.push(artifact);
+        gameArtifacts.set(gameId, arr);
+      }
+    }
+
+    const winners = new Set<string>();
+    for (const group of gameArtifacts.values()) {
+      const mapped = group.map((a) => ({
+        id: a.id,
+        release: { region: a.release?.region },
+        verified: (a as any).verified ?? undefined,
+        revision: (a.release as any)?.revision ?? undefined,
+      }));
+      const { winner } = pickWinner(mapped, prefs);
+      if (winner) winners.add(winner.id);
+    }
+
+    for (const library of platform.libraries) {
+      for (const artifact of library.artifacts) {
+        if (!artifact.release) continue;
+        if (!winners.has(artifact.id)) continue;
         const game = artifact.release.game;
         const key = `${game.provider}:${game.providerId}`;
         if (!gameCache.has(key)) {

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -5,3 +5,4 @@ export * from './parsers/cue.js';
 export * from './parsers/gdi.js';
 export * from './organize/renderTemplate.js';
 export * from './organize/moveArtifact.js';
+export * from './organize/oneGameOneRom.js';

--- a/packages/domain/src/organize/oneGameOneRom.ts
+++ b/packages/domain/src/organize/oneGameOneRom.ts
@@ -1,0 +1,56 @@
+export interface OgoPreferences {
+  regionPriority: string[];
+  preferVerified: boolean;
+  preferHighestRevision: boolean;
+}
+
+export interface OgoArtifact {
+  id: string;
+  verified?: boolean | null;
+  revision?: number | null;
+  release?: { region?: string | null } | null;
+}
+
+export interface OgoResult {
+  winner: OgoArtifact | null;
+  secondary: OgoArtifact[];
+}
+
+export function pickWinner(
+  artifacts: OgoArtifact[],
+  prefs: OgoPreferences,
+): OgoResult {
+  if (artifacts.length === 0) return { winner: null, secondary: [] };
+  const scored = artifacts.map((a) => ({
+    artifact: a,
+    score: computeScore(a, prefs),
+  }));
+  scored.sort((a, b) => a.score - b.score);
+  const [first, ...rest] = scored;
+  return {
+    winner: first.artifact,
+    secondary: rest.map((s) => s.artifact),
+  };
+}
+
+function computeScore(a: OgoArtifact, prefs: OgoPreferences): number {
+  let score = 0;
+  // region priority
+  if (a.release?.region) {
+    const idx = prefs.regionPriority.indexOf(a.release.region);
+    score += idx === -1 ? prefs.regionPriority.length : idx;
+  } else {
+    score += prefs.regionPriority.length + 1;
+  }
+  // verified dumps preferred
+  if (prefs.preferVerified) {
+    score += a.verified ? 0 : prefs.regionPriority.length + 2;
+  }
+  // highest revision preferred
+  if (prefs.preferHighestRevision) {
+    // higher revision should have lower score (better)
+    const rev = a.revision ?? -Infinity;
+    score -= rev / 1000; // small factor to influence ordering
+  }
+  return score;
+}


### PR DESCRIPTION
## Summary
- add OneGameOneRom service with region, verification, and revision preferences
- export only selected artifacts in EmulationStation exporter
- expose OneGameOneRom preferences via basic web settings page

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af7bb90b5083309a90d661178c5d8d