### PR TITLE
docs: add project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ pnpm -w dev
 ```bash
 pnpm -w build
 ```
+
+## Documentation
+
+Additional guides and references live in the [docs](./docs) directory.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation
+
+- [Architecture](./architecture.md)
+- [Local Development](./local-dev.md)
+- [Configuration](./configuration.md)
+- [Installing](./installing.md)
+- [Backup & Restore](./backup-restore.md)
+- [Troubleshooting](./troubleshooting.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,62 @@
+# Architecture
+
+This document outlines the gamarr system using the [C4 model](https://c4model.com/).
+
+## Context
+
+```mermaid
+C4Context
+title System Context
+Person(user, "User")
+System_Boundary(gamarr, "gamarr") {
+  Container(web, "Web", "React", "User-facing UI")
+  Container(api, "API", "NestJS", "HTTP API")
+  Container(worker, "Worker", "NestJS", "Background jobs")
+}
+System_Ext(rawg, "RAWG API")
+System_Ext(igdb, "IGDB API")
+System_Ext(qbt, "qBittorrent")
+Rel(user, web, "Uses")
+Rel(web, api, "Makes requests")
+Rel(api, worker, "Enqueues jobs")
+Rel(api, rawg, "Fetches game data")
+Rel(worker, igdb, "Enriches data")
+Rel(worker, qbt, "Manages downloads")
+```
+
+## Container
+
+```mermaid
+C4Container
+title Container diagram
+Boundary(gamarr, "gamarr") {
+  Container(web, "Web", "Vite/React", "SPA served to users")
+  Container(api, "API", "NestJS", "Handles HTTP requests")
+  Container(worker, "Worker", "NestJS", "Processes background jobs")
+  ContainerDb(db, "PostgreSQL", "Relational database")
+  Container(redis, "Redis", "Queues and caching")
+  Container(qbt, "qBittorrent", "Download client")
+}
+Rel(web, api, "HTTP/JSON")
+Rel(api, db, "Reads/writes")
+Rel(api, redis, "Publishes jobs")
+Rel(worker, redis, "Consumes jobs")
+Rel(worker, db, "Reads/writes")
+Rel(worker, qbt, "Controls downloads")
+```
+
+## Component
+
+```mermaid
+C4Component
+title API Component diagram
+Container_Boundary(api, "API") {
+  Component(controller, "Controllers", "NestJS", "HTTP endpoints")
+  Component(service, "Services", "NestJS", "Application logic")
+  Component(domain, "Domain", "Shared", "Business rules")
+  Component(storage, "Storage", "Prisma", "Database access")
+}
+Rel(controller, service, "Calls")
+Rel(service, domain, "Uses")
+Rel(service, storage, "Reads/writes")
+```

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -1,0 +1,25 @@
+# Backup & Restore
+
+Persistent data lives in the `data/`, `lib/`, and `downloads/` directories and in the Postgres database.
+
+## Backup
+
+1. Dump the database:
+   ```bash
+   docker compose -f infra/docker-compose.yml exec postgres pg_dump -U gamearr gamearr > backup.sql
+   ```
+2. Archive persistent directories:
+   ```bash
+   tar czf data.tar.gz data lib downloads
+   ```
+
+## Restore
+
+1. Restore directories:
+   ```bash
+   tar xzf data.tar.gz
+   ```
+2. Restore the database:
+   ```bash
+   cat backup.sql | docker compose -f infra/docker-compose.yml exec -T postgres psql -U gamearr gamearr
+   ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,20 @@
+# Configuration
+
+The project is configured through environment variables. Copy `.env.example` to `.env` and provide values for the following keys:
+
+| Variable | Description |
+| --- | --- |
+| `POSTGRES_PASSWORD` | Password for the local Postgres instance. |
+| `DB_URL` | Connection string used by the API and Prisma client. |
+| `REDIS_URL` | Redis instance used for queues and caching. |
+| `RAWG_KEY` | API key for the RAWG game database. |
+| `IGDB_CLIENT_ID` | IGDB client identifier. |
+| `IGDB_CLIENT_SECRET` | IGDB client secret. |
+| `LIB_ROOT` | Path where processed games are stored. |
+| `DOWNLOADS_ROOT` | Directory for temporary downloads. |
+| `DATA_ROOT` | Persistent data directory for services. |
+| `QBITTORRENT_URL` | URL of the qBittorrent client. |
+| `QBITTORRENT_USERNAME` | qBittorrent username. |
+| `QBITTORRENT_PASSWORD` | qBittorrent password. |
+| `NOINTRO_DAT_URL` | URL to the No-Intro DAT file. |
+| `NOINTRO_PLATFORM_ID` | No-Intro identifier for the target platform. |

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -1,0 +1,30 @@
+# Installing
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- [pnpm](https://pnpm.io/)
+- [Docker Compose](https://docs.docker.com/compose/)
+
+## Steps
+
+1. Clone the repository and change into its directory.
+2. Copy `.env.example` to `.env` and set values.
+3. Install dependencies:
+   ```bash
+   pnpm -w install
+   ```
+4. Start supporting services:
+   ```bash
+   pnpm dev:infra
+   ```
+5. Run database migrations:
+   ```bash
+   pnpm migrate
+   ```
+6. Build the apps:
+   ```bash
+   pnpm -w build
+   ```
+
+The built artifacts reside in each app's `dist/` folder. Start the API or worker using Node or a process manager of your choice.

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,25 @@
+# Local Development
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) 18+
+- [pnpm](https://pnpm.io/)
+- [Docker Compose](https://docs.docker.com/compose/)
+
+## Setup
+
+1. Copy `.env.example` to `.env` and adjust values as needed.
+2. Start the infrastructure services:
+   ```bash
+   pnpm dev:infra
+   ```
+3. Install dependencies:
+   ```bash
+   pnpm -w install
+   ```
+4. Run all apps:
+   ```bash
+   pnpm -w dev
+   ```
+
+Individual apps can be started with `pnpm dev:api`, `pnpm dev:worker`, or `pnpm dev:web`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,26 @@
+# Troubleshooting
+
+## Services fail to start
+- Ensure Docker is running and infrastructure services are up: `pnpm dev:infra`.
+- Check container status with:
+  ```bash
+  docker compose -f infra/docker-compose.yml ps
+  ```
+
+## Database connection errors
+- Verify `DB_URL` and that migrations have been applied: `pnpm migrate`.
+
+## Prisma client missing
+- Regenerate the client:
+  ```bash
+  pnpm storage-generate
+  ```
+
+## Port already in use
+- Stop the process using the port or change the configuration in `.env`.
+
+## Getting more logs
+- Inspect application logs or run containers in the foreground:
+  ```bash
+  docker compose -f infra/docker-compose.yml logs -f
+  ```


### PR DESCRIPTION
## Summary
- document architecture using C4 model diagrams
- add guides for local development, configuration, installing, backup/restore, and troubleshooting
- link documentation from the README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b098a155848330a0856e86b0b1557a