### PR TITLE
docs: add contributing and policy guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement. All complaints
+will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Install dependencies with `pnpm -w install`.
+3. Run the tests and linter with `pnpm -w test` and `pnpm -w lint`.
+4. Make your changes on a new branch and add tests when possible.
+5. Ensure all checks pass before opening a pull request.
+
+## Code of Conduct
+
+This project adheres to the [Code of Conduct](./CODE_OF_CONDUCT.md). By
+participating, you are expected to uphold this code.
+
+## License
+
+Contributions to this project are made under the terms of the
+[Apache 2.0 License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gamarr
 
-[![CI](https://github.com/OWNER/gamarr/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/gamarr/actions/workflows/ci.yml)
-[![Docker](https://img.shields.io/docker/pulls/OWNER/gamarr?logo=docker)](https://hub.docker.com/r/OWNER/gamarr)
+[![CI](https://github.com/homeputers/gamarr/actions/workflows/ci.yml/badge.svg)](https://github.com/homeputers/gamarr/actions/workflows/ci.yml)
+[![Docker](https://img.shields.io/docker/pulls/homeputers/gamarr?logo=docker)](https://hub.docker.com/r/homeputers/gamarr)
 [![Docs](https://img.shields.io/badge/docs-available-blue.svg)](./docs)
 
 Monorepo managed with [Turborepo](https://turbo.build/) and [pnpm](https://pnpm.io/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # gamarr
 
+[![CI](https://github.com/OWNER/gamarr/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/gamarr/actions/workflows/ci.yml)
+[![Docker](https://img.shields.io/docker/pulls/OWNER/gamarr?logo=docker)](https://hub.docker.com/r/OWNER/gamarr)
+[![Docs](https://img.shields.io/badge/docs-available-blue.svg)](./docs)
+
 Monorepo managed with [Turborepo](https://turbo.build/) and [pnpm](https://pnpm.io/).
 
 ## Workspaces

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,6 @@
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability, please report it by
-[opening an issue](https://github.com/OWNER/gamarr/issues) or by contacting the
+[opening an issue](https://github.com/homeputers/gamarr/issues) or by contacting the
 maintainers directly. We will aim to respond promptly and work with you to
 address the issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it by
+[opening an issue](https://github.com/OWNER/gamarr/issues) or by contacting the
+maintainers directly. We will aim to respond promptly and work with you to
+address the issue.


### PR DESCRIPTION
## Summary
- add Contributor Covenant code of conduct
- document how to contribute and report security issues
- show CI, Docker, and docs badges in README

## Testing
- `pnpm -w lint`
- `pnpm -w test` *(fails: Cannot find module 'fast-xml-parser')*

------
https://chatgpt.com/codex/tasks/task_e_68b0a026c2288330b4b0e2b7843b9a3d